### PR TITLE
Add rest_framework to INSTALLED_APPS

### DIFF
--- a/OTP_auth/settings.py
+++ b/OTP_auth/settings.py
@@ -38,8 +38,10 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'custom_users',
-    'knox'
+    'knox',
+    'rest_framework'
 ]
+
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
The `'rest_framework'` added to INSTALLED_APPS  to solve errors about this library.